### PR TITLE
Enable evdev input in dummy SDL backend

### DIFF
--- a/SDL2/src/core/linux/SDL_evdev.c
+++ b/SDL2/src/core/linux/SDL_evdev.c
@@ -38,6 +38,14 @@
 #include <sys/ioctl.h>
 #include <linux/input.h>
 
+#if !SDL_USE_LIBUDEV
+#include <dirent.h>
+#include <limits.h>
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+#endif
+
 #include "SDL.h"
 #include "SDL_assert.h"
 #include "SDL_endian.h"
@@ -110,13 +118,21 @@ static _THIS = NULL;
 
 static SDL_Scancode SDL_EVDEV_translate_keycode(int keycode);
 static void SDL_EVDEV_sync_device(SDL_evdevlist_item *item);
+#if SDL_USE_LIBUDEV
+static int SDL_EVDEV_init_touchscreen(SDL_evdevlist_item* item);
+#endif
 static int SDL_EVDEV_device_removed(const char *dev_path);
+static int SDL_EVDEV_add_device(const char *dev_path, SDL_bool is_touchscreen);
 
 #if SDL_USE_LIBUDEV
 static int SDL_EVDEV_device_added(const char *dev_path, int udev_class);
 static void SDL_EVDEV_udev_callback(SDL_UDEV_deviceevent udev_type, int udev_class,
     const char *dev_path);
 #endif /* SDL_USE_LIBUDEV */
+
+#if !SDL_USE_LIBUDEV
+static void SDL_EVDEV_scan_devices(void);
+#endif
 
 static Uint8 EVDEV_MouseButtons[] = {
     SDL_BUTTON_LEFT,            /*  BTN_LEFT        0x110 */
@@ -164,7 +180,7 @@ SDL_EVDEV_Init(void)
         /* Force a scan to build the initial device list */
         SDL_UDEV_Scan();
 #else
-        /* TODO: Scan the devices manually, like a caveman */
+        SDL_EVDEV_scan_devices();
 #endif /* SDL_USE_LIBUDEV */
 
         _this->kbd = SDL_EVDEV_kbd_init();
@@ -703,11 +719,9 @@ SDL_EVDEV_sync_device(SDL_evdevlist_item *item)
 #endif /* EVIOCGMTSLOTS */
 }
 
-#if SDL_USE_LIBUDEV
 static int
-SDL_EVDEV_device_added(const char *dev_path, int udev_class)
+SDL_EVDEV_add_device(const char *dev_path, SDL_bool is_touchscreen)
 {
-    int ret;
     SDL_evdevlist_item *item;
 
     /* Check to make sure it's not already in list. */
@@ -735,15 +749,22 @@ SDL_EVDEV_device_added(const char *dev_path, int udev_class)
         return SDL_OutOfMemory();
     }
 
-    if (udev_class & SDL_UDEV_DEVICE_TOUCHSCREEN) {
+#if SDL_USE_LIBUDEV
+    if (is_touchscreen) {
+        int ret;
+
         item->is_touchscreen = 1;
 
         if ((ret = SDL_EVDEV_init_touchscreen(item)) < 0) {
             close(item->fd);
+            SDL_free(item->path);
             SDL_free(item);
             return ret;
         }
     }
+#else
+    (void)is_touchscreen;
+#endif
 
     if (_this->last == NULL) {
         _this->first = _this->last = item;
@@ -756,7 +777,53 @@ SDL_EVDEV_device_added(const char *dev_path, int udev_class)
 
     return _this->num_devices++;
 }
+
+#if SDL_USE_LIBUDEV
+static int
+SDL_EVDEV_device_added(const char *dev_path, int udev_class)
+{
+    SDL_bool is_touchscreen = SDL_FALSE;
+
+    if (udev_class & SDL_UDEV_DEVICE_TOUCHSCREEN) {
+        is_touchscreen = SDL_TRUE;
+    }
+
+    return SDL_EVDEV_add_device(dev_path, is_touchscreen);
+}
 #endif /* SDL_USE_LIBUDEV */
+
+#if !SDL_USE_LIBUDEV
+static void
+SDL_EVDEV_scan_devices(void)
+{
+    DIR *dirp;
+    struct dirent *dent;
+    char dev_path[PATH_MAX];
+    static const char input_dir[] = "/dev/input";
+    int len;
+
+    dirp = opendir(input_dir);
+    if (!dirp) {
+        return;
+    }
+
+    while ((dent = readdir(dirp)) != NULL) {
+        if (SDL_strncmp(dent->d_name, "event", 5) != 0) {
+            continue;
+        }
+
+        len = SDL_snprintf(dev_path, sizeof(dev_path), "%s/%s", input_dir, dent->d_name);
+        if (len < 0 || len >= (int)sizeof(dev_path)) {
+            continue;
+        }
+
+        SDL_EVDEV_add_device(dev_path, SDL_FALSE);
+    }
+
+    closedir(dirp);
+}
+#endif /* !SDL_USE_LIBUDEV */
+
 
 static int
 SDL_EVDEV_device_removed(const char *dev_path)

--- a/SDL2/src/core/linux/SDL_evdev.c
+++ b/SDL2/src/core/linux/SDL_evdev.c
@@ -37,6 +37,8 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <linux/input.h>
+#include <errno.h>
+#include <string.h>
 
 #if !SDL_USE_LIBUDEV
 #include <dirent.h>
@@ -231,6 +233,7 @@ SDL_EVDEV_Init(void)
         /* Force a scan to build the initial device list */
         SDL_UDEV_Scan();
 #else
+        SDL_LogInfo(SDL_LOG_CATEGORY_INPUT, "evdev: performing initial device scan");
         SDL_EVDEV_scan_devices();
 #endif /* SDL_USE_LIBUDEV */
 
@@ -322,9 +325,21 @@ SDL_EVDEV_Poll(void)
     mouse = SDL_GetMouse();
 
     for (item = _this->first; item != NULL; item = item->next) {
+        len = 0;
         while ((len = read(item->fd, events, (sizeof events))) > 0) {
-            len /= sizeof(events[0]);
-            for (i = 0; i < len; ++i) {
+            int num_events = len / (int)sizeof(events[0]);
+
+            SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
+                         "evdev: read %d events from %s",
+                         num_events,
+                         item->path);
+
+            for (i = 0; i < num_events; ++i) {
+                SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
+                             "evdev: event type=%hu code=%hu value=%d",
+                             events[i].type,
+                             events[i].code,
+                             events[i].value);
                 /* special handling for touchscreen, that should eventually be
                    used for all devices */
                 if (item->out_of_sync && item->is_touchscreen &&
@@ -504,7 +519,14 @@ SDL_EVDEV_Poll(void)
                     break;
                 }
             }
-        }    
+        }
+
+        if (len < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_INPUT,
+                        "evdev: read error on %s: %s",
+                        item->path,
+                        strerror(errno));
+        }
     }
 }
 
@@ -771,6 +793,8 @@ static int
 SDL_EVDEV_add_device(const char *dev_path, SDL_bool is_touchscreen)
 {
     SDL_evdevlist_item *item;
+    char name[256];
+    int have_name;
 
     /* Check to make sure it's not already in list. */
     for (item = _this->first; item != NULL; item = item->next) {
@@ -786,8 +810,12 @@ SDL_EVDEV_add_device(const char *dev_path, SDL_bool is_touchscreen)
 
     item->fd = open(dev_path, O_RDONLY | O_NONBLOCK);
     if (item->fd < 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_INPUT,
+                    "evdev: unable to open %s: %s",
+                    dev_path,
+                    strerror(errno));
         SDL_free(item);
-        return SDL_SetError("Unable to open %s", dev_path);
+        return SDL_SetError("Unable to open %s: %s", dev_path, strerror(errno));
     }
 
     item->path = SDL_strdup(dev_path);
@@ -797,11 +825,44 @@ SDL_EVDEV_add_device(const char *dev_path, SDL_bool is_touchscreen)
         return SDL_OutOfMemory();
     }
 
+    have_name = ioctl(item->fd, EVIOCGNAME(sizeof(name)), name);
+    if (have_name < 0) {
+        name[0] = '\0';
+    } else {
+        if (have_name >= (int)sizeof(name)) {
+            have_name = (int)sizeof(name) - 1;
+        }
+        name[have_name] = '\0';
+    }
+
+    if (have_name == 0) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_INPUT,
+                    "evdev: opened %s (fd %d)",
+                    dev_path,
+                    item->fd);
+    } else if (have_name > 0) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_INPUT,
+                    "evdev: opened %s (fd %d) name='%s'",
+                    dev_path,
+                    item->fd,
+                    name);
+    } else {
+        SDL_LogWarn(SDL_LOG_CATEGORY_INPUT,
+                    "evdev: opened %s (fd %d) but could not query name: %s",
+                    dev_path,
+                    item->fd,
+                    strerror(errno));
+    }
+
 #if SDL_USE_LIBUDEV
     if (is_touchscreen) {
         int ret;
 
         item->is_touchscreen = 1;
+
+        SDL_LogInfo(SDL_LOG_CATEGORY_INPUT,
+                    "evdev: %s flagged as touchscreen via udev classification",
+                    dev_path);
 
         if ((ret = SDL_EVDEV_init_touchscreen(item)) < 0) {
             close(item->fd);
@@ -815,6 +876,10 @@ SDL_EVDEV_add_device(const char *dev_path, SDL_bool is_touchscreen)
         int ret;
 
         item->is_touchscreen = 1;
+
+        SDL_LogInfo(SDL_LOG_CATEGORY_INPUT,
+                    "evdev: %s appears to be a touchscreen (fallback detection)",
+                    dev_path);
 
         if ((ret = SDL_EVDEV_init_touchscreen(item)) < 0) {
             close(item->fd);
@@ -844,6 +909,11 @@ SDL_EVDEV_device_added(const char *dev_path, int udev_class)
 {
     SDL_bool is_touchscreen = SDL_FALSE;
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_INPUT,
+                "evdev: udev reported device %s class=0x%x",
+                dev_path,
+                udev_class);
+
     if (udev_class & SDL_UDEV_DEVICE_TOUCHSCREEN) {
         is_touchscreen = SDL_TRUE;
     }
@@ -864,6 +934,10 @@ SDL_EVDEV_scan_devices(void)
 
     dirp = opendir(input_dir);
     if (!dirp) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_INPUT,
+                    "evdev: failed to open %s: %s",
+                    input_dir,
+                    strerror(errno));
         return;
     }
 
@@ -877,6 +951,9 @@ SDL_EVDEV_scan_devices(void)
             continue;
         }
 
+        SDL_LogInfo(SDL_LOG_CATEGORY_INPUT,
+                    "evdev: considering %s for monitoring",
+                    dev_path);
         SDL_EVDEV_add_device(dev_path, SDL_FALSE);
     }
 
@@ -894,6 +971,9 @@ SDL_EVDEV_device_removed(const char *dev_path)
     for (item = _this->first; item != NULL; item = item->next) {
         /* found it, remove it. */
         if (SDL_strcmp(dev_path, item->path) == 0) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_INPUT,
+                        "evdev: removing %s",
+                        dev_path);
             if (prev != NULL) {
                 prev->next = item->next;
             } else {
@@ -915,6 +995,9 @@ SDL_EVDEV_device_removed(const char *dev_path)
         prev = item;
     }
 
+    SDL_LogWarn(SDL_LOG_CATEGORY_INPUT,
+                "evdev: attempted to remove unknown device %s",
+                dev_path);
     return -1;
 }
 

--- a/SDL2/src/core/linux/SDL_evdev.c
+++ b/SDL2/src/core/linux/SDL_evdev.c
@@ -118,9 +118,7 @@ static _THIS = NULL;
 
 static SDL_Scancode SDL_EVDEV_translate_keycode(int keycode);
 static void SDL_EVDEV_sync_device(SDL_evdevlist_item *item);
-#if SDL_USE_LIBUDEV
 static int SDL_EVDEV_init_touchscreen(SDL_evdevlist_item* item);
-#endif
 static int SDL_EVDEV_device_removed(const char *dev_path);
 static int SDL_EVDEV_add_device(const char *dev_path, SDL_bool is_touchscreen);
 
@@ -132,6 +130,59 @@ static void SDL_EVDEV_udev_callback(SDL_UDEV_deviceevent udev_type, int udev_cla
 
 #if !SDL_USE_LIBUDEV
 static void SDL_EVDEV_scan_devices(void);
+#define SDL_EVDEV_BITS_PER_LONG   (sizeof(unsigned long) * 8)
+#define SDL_EVDEV_BITMASK_SIZE(max) (((max) + SDL_EVDEV_BITS_PER_LONG) / SDL_EVDEV_BITS_PER_LONG)
+
+static SDL_bool
+SDL_EVDEV_bitmask_test(const unsigned long *bitmask, int bit)
+{
+    return (bitmask[bit / SDL_EVDEV_BITS_PER_LONG] & (1UL << (bit % SDL_EVDEV_BITS_PER_LONG))) != 0;
+}
+
+static SDL_bool
+SDL_EVDEV_GuessIsTouchscreen(int fd)
+{
+    unsigned long evbit[SDL_EVDEV_BITMASK_SIZE(EV_MAX)];
+    unsigned long absbit[SDL_EVDEV_BITMASK_SIZE(ABS_MAX)];
+    unsigned long keybit[SDL_EVDEV_BITMASK_SIZE(KEY_MAX)];
+
+    SDL_memset(evbit, 0, sizeof(evbit));
+    if (ioctl(fd, EVIOCGBIT(0, sizeof(evbit)), evbit) < 0) {
+        return SDL_FALSE;
+    }
+
+    if (!SDL_EVDEV_bitmask_test(evbit, EV_ABS)) {
+        return SDL_FALSE;
+    }
+
+    SDL_memset(absbit, 0, sizeof(absbit));
+    if (ioctl(fd, EVIOCGBIT(EV_ABS, sizeof(absbit)), absbit) < 0) {
+        return SDL_FALSE;
+    }
+
+    if (SDL_EVDEV_bitmask_test(absbit, ABS_MT_POSITION_X) &&
+        SDL_EVDEV_bitmask_test(absbit, ABS_MT_POSITION_Y)) {
+        return SDL_TRUE;
+    }
+
+    if (!SDL_EVDEV_bitmask_test(absbit, ABS_X) ||
+        !SDL_EVDEV_bitmask_test(absbit, ABS_Y)) {
+        return SDL_FALSE;
+    }
+
+    SDL_memset(keybit, 0, sizeof(keybit));
+    if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keybit)), keybit) < 0) {
+        return SDL_FALSE;
+    }
+
+    if (SDL_EVDEV_bitmask_test(keybit, BTN_TOUCH) ||
+        SDL_EVDEV_bitmask_test(keybit, BTN_STYLUS) ||
+        SDL_EVDEV_bitmask_test(keybit, BTN_TOOL_FINGER)) {
+        return SDL_TRUE;
+    }
+
+    return SDL_FALSE;
+}
 #endif
 
 static Uint8 EVDEV_MouseButtons[] = {
@@ -481,7 +532,6 @@ SDL_EVDEV_translate_keycode(int keycode)
     return scancode;
 }
 
-#ifdef SDL_USE_LIBUDEV
 static int
 SDL_EVDEV_init_touchscreen(SDL_evdevlist_item* item)
 {
@@ -581,8 +631,6 @@ SDL_EVDEV_init_touchscreen(SDL_evdevlist_item* item)
 
     return 0;
 }
-#endif /* SDL_USE_LIBUDEV */
-
 static void
 SDL_EVDEV_destroy_touchscreen(SDL_evdevlist_item* item) {
     if (!item->is_touchscreen)
@@ -763,6 +811,18 @@ SDL_EVDEV_add_device(const char *dev_path, SDL_bool is_touchscreen)
         }
     }
 #else
+    if (SDL_EVDEV_GuessIsTouchscreen(item->fd)) {
+        int ret;
+
+        item->is_touchscreen = 1;
+
+        if ((ret = SDL_EVDEV_init_touchscreen(item)) < 0) {
+            close(item->fd);
+            SDL_free(item->path);
+            SDL_free(item);
+            return ret;
+        }
+    }
     (void)is_touchscreen;
 #endif
 

--- a/SDL2/src/video/dummy/SDL_nullevents.c
+++ b/SDL2/src/video/dummy/SDL_nullevents.c
@@ -26,6 +26,7 @@
    most of the API. */
 
 #include "../../events/SDL_events_c.h"
+#include "../../core/linux/SDL_evdev.h"
 
 #include "SDL_nullvideo.h"
 #include "SDL_nullevents_c.h"
@@ -33,7 +34,9 @@
 void
 DUMMY_PumpEvents(_THIS)
 {
-    /* do nothing. */
+#ifdef SDL_INPUT_LINUXEV
+    SDL_EVDEV_Poll();
+#endif
 }
 
 #endif /* SDL_VIDEO_DRIVER_DUMMY */

--- a/SDL2/src/video/dummy/SDL_nullvideo.c
+++ b/SDL2/src/video/dummy/SDL_nullvideo.c
@@ -42,6 +42,7 @@
 #include "../SDL_sysvideo.h"
 #include "../SDL_pixels_c.h"
 #include "../../events/SDL_events_c.h"
+#include "../../core/linux/SDL_evdev.h"
 
 #include "SDL_nullvideo.h"
 #include "SDL_nullevents_c.h"
@@ -124,6 +125,12 @@ DUMMY_VideoInit(_THIS)
     SDL_zero(mode);
     SDL_AddDisplayMode(&_this->displays[0], &mode);
 
+#ifdef SDL_INPUT_LINUXEV
+    if (SDL_EVDEV_Init() < 0) {
+        return -1;
+    }
+#endif
+
     /* We're done! */
     return 0;
 }
@@ -137,6 +144,9 @@ DUMMY_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
 void
 DUMMY_VideoQuit(_THIS)
 {
+#ifdef SDL_INPUT_LINUXEV
+    SDL_EVDEV_Quit();
+#endif
 }
 
 #endif /* SDL_VIDEO_DRIVER_DUMMY */


### PR DESCRIPTION
## Summary
- integrate evdev initialization, polling, and cleanup into the dummy video backend so evdev devices are serviced
- add a manual /dev/input/event* scanning fallback to SDL_EVDEV_Init when libudev is unavailable

## Testing
- cmake -S SDL2 -B SDL2/build -DSDL_STATIC=ON -DSDL_SHARED=OFF
- cmake --build SDL2/build

------
https://chatgpt.com/codex/tasks/task_e_68cf1c7fe2948321a09859ba6db5bbd1