### PR TITLE
Add sequential roadmap

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -1,5 +1,7 @@
 # Development Checklist
 
+## Abgeschlossen
+
 - [x] Enable the touch overlay by default in the Linux armhf GLES2 build configuration.
 - [x] Mirror the default touch overlay define in the desktop Linux GLES2 build output.
 - [x] Fix the SDL input overlay compilation errors introduced by forcing the overlay define on by default.
@@ -22,5 +24,16 @@
 - [x] Short-circuit controller hot-plug handling when `SDL_GameControllerOpen` fails and guard name lookups behind a valid handle check.
 - [x] Gracefully fall back to sysroot D-Bus headers when pkg-config metadata is missing during armhf builds, staging host copies into the sysroot when necessary.
 - [x] Stamp the SailfishOS Premake makefiles with hard-float ARM tuning so glibc no longer requests the soft-float stubs headers during cross-builds.
-- [ ] Validate the GLES2 build on actual Sailfish OS hardware to confirm the runtime touch overlay visuals.
-- [ ] Provide GLESv2, EGL, and SDL2 development libraries in the build environment (or cross toolchain) so linking succeeds locally.
+
+## Offene Schritte (Roadmap-Reihenfolge)
+
+1. [ ] Validate the GLES2 build on actual Sailfish OS hardware to confirm the runtime touch overlay visuals.
+2. [ ] Provide GLESv2, EGL, and SDL2 development libraries in the build environment (or cross toolchain) so linking succeeds locally.
+3. [ ] Extend the documentation with guided walkthroughs for `build_rpm.sh` und `build_armhf.sh`.
+4. [ ] Implement an on-screen keyboard within the touch overlay and add optional aim-assist/modifier controls.
+5. [ ] Optimise the GLES2 rendering path (Buffer-Management, Shader, Frame-Interpolation) für mobile Performance.
+6. [ ] Automate cross-builds and package linting via a CI-Pipeline auf Basis der vorhandenen Skripte.
+7. [ ] Ergänzen von Overlay-Presets und Skalierungsoptionen für verschiedene Displaygrößen.
+8. [ ] Expand platform support (z. B. ARM64, Wayland-first) innerhalb der Premake-Projekte und Release-Artefakte.
+9. [ ] Aktualisieren der gebündelten Third-Party-Bibliotheken und Etablieren eines Security-Update-Prozesses.
+10. [ ] Einführen regelmäßiger Beta-Builds und Hardware-QA-Schleifen zur frühzeitigen Regressionserkennung.

--- a/readme.md
+++ b/readme.md
@@ -57,3 +57,15 @@ When those taps are injected into the GL virtual keyboard layer, the backend now
 Those joystick and look rectangles are now invalidated whenever the window is resized, the device orientation flips, or the Sailfish FBO scale changes.  The next touch event rebuilds the regions against the live window metrics, keeping finger classification synchronised with the rendered overlay even after dynamic resolution switches or display rotations.
 
 When SDL refuses to open a detected game controller, the input backend now logs the failure with the `SDL_GetError()` message rather than handing a `NULL` pointer to `SDL_GameControllerName`.  The hot-unplug close path mirrors that guard so unexpected device enumeration blips write an informative diagnostic line instead of crashing inside the formatter.
+
+## Roadmap (Ablauforientiert)
+
+1. **Bestehende Builds stabilisieren** – Die jüngsten GLES2-Änderungen auf realer Sailfish-Hardware verifizieren und fehlende Grafik-/SDL-Entwicklungsbibliotheken in den Build-Umgebungen hinterlegen, damit Releases und Cross-Builds reproduzierbar laufen.
+2. **Build-Tooling dokumentieren** – Schritt-für-Schritt-Anleitungen für `build_rpm.sh` und `build_armhf.sh` ergänzen, damit Maintainer die bereitgestellten Automatisierungsskripte ohne Vorkenntnisse einsetzen können.
+3. **Touch-Eingabe vervollständigen** – Eine Bildschirmtastatur in das Overlay integrieren und optionale Auto-Aiming-/Modifikator-Funktionen bereitstellen, um Touch- und Controller-Steuerung zu verbessern.
+4. **Rendering-Pfade modernisieren** – Die GLES2-Pipeline weiter optimieren (Pufferverwaltung, Shader-Pfade, Frame-Interpolation), damit mobile Geräte von stabileren Framerates profitieren.
+5. **Builds automatisieren** – Eine wiederholbare CI-Pipeline aufsetzen, die Cross-Builds, Paketprüfungen und Smoke-Tests orchestriert und die lokalen Skripte nutzt.
+6. **Overlay-Erlebnis erweitern** – Layout-Presets, Skalierungen und Konfigurationsprofile für unterschiedliche Displaygrößen anbieten, damit Nutzer das Overlay schnell anpassen können.
+7. **Portierungsgrad ausbauen** – Weitere Zielplattformen (z. B. 64-Bit-ARM, Wayland-first Builds) in die Premake-Projekte einpflegen und sicherstellen, dass benötigte Artefakte im Sailfish-Ökosystem ausgeliefert werden.
+8. **Abhängigkeiten pflegen** – Die gebündelten Third-Party-Bibliotheken aktualisieren und einen Prozess etablieren, der Sicherheitsfixes zeitnah in Builds und Pakete übernimmt.
+9. **QA-Feedbackschleifen etablieren** – Regelmäßige Beta-Builds und Hardware-Tests veröffentlichen, um Regressionen in Touch-Steuerung und Rendering frühzeitig zu entdecken und in zukünftigen Iterationen zu berücksichtigen.


### PR DESCRIPTION
## Summary
- document a procedure-oriented roadmap in the README to guide future development
- reorganise the development checklist to mirror the new roadmap order and highlight open steps

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2fcfe23bc83218faca1bf1737cf6c